### PR TITLE
docs: describe example architecture based on ports and adapters

### DIFF
--- a/src/main/markdown/application-test.md
+++ b/src/main/markdown/application-test.md
@@ -1,0 +1,59 @@
+<!--
+SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Application test (Draft)
+
+In the application test
+we test a piece of application logic without its dependencies.
+This is at the core of the Ports and Adapters pattern.
+We test the application by sending messages to one of its primary ports
+and inspect the result of return values
+and calls made to (or state changes in) secondary adapters.
+
+In our exemple, we test by invoking methods on the `UserService`
+and inspect the return values.
+Instead of using a real database,
+we can either us a fake in memory implementation of the `UserStore`
+or we could stub it on a test by test basis.
+
+```mermaid
+---
+  config:
+    class:
+      hideEmptyMembersBox: true
+---
+classDiagram
+    direction TD
+
+    note for InMemoryUserStore "By using an in memory implementation
+    of the UserStore we can test the core
+    application logic end to end without
+    any infrastructure details."
+
+    class UserServiceTest
+    UserServiceTest --> UserService
+    UserServiceTest --> InMemoryUserStore
+
+    class InMemoryUserStore
+    InMemoryUserStore --|> UserStore
+
+    namespace com.example.demo.application {
+        class UserService
+        class UserStore
+        class User
+        class UserData
+    }
+    <<interface>> UserStore
+    UserStore <-- UserService
+
+    UserService --> UserData
+    UserService : get(id) UserData
+    UserService : save(UserData user)
+
+    UserStore --> User
+    UserStore : get(id) User
+    UserStore : save(User user)
+```

--- a/src/main/markdown/architecture-overview.md
+++ b/src/main/markdown/architecture-overview.md
@@ -1,0 +1,164 @@
+<!--
+SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Architecture Overview (Draft)
+
+The architecture proposed here is based on
+[the Hexagonal (Ports & Adapters) Architecture](
+    https://alistair.cockburn.us/hexagonal-architecture
+)
+introduced by Alistair Cockburn in 2005.
+
+The main idea is to decouple the application from its external dependencies
+so that it can be run and tested without the need of
+a user interface, a database, message queues etc.
+
+> Allow an application to equally be driven by
+> users, programs, automated test or batch scripts,
+> and to be developed and tested in isolation from its eventual run-time devices and databases.
+
+
+## Ports
+
+To decouple the application from its dependencies,
+a set of *ports* (or interfaces) are defined by the application.
+These ports are defined in a technology agnostic way
+and speaks the language of the appplication.
+In other words,
+it does not use the terms or defifintions of any technology framework or tool like Spring, JPA or JDBC.
+
+
+## Adapters
+
+With these ports defined,
+it is the responsibility of *adapters* to translate,
+or adapt,
+the application needs into a particular technology,
+e.g. using Spring Data to implemenent persistence
+or Spring MVC to map HTTP requests into application logic.
+
+
+## Primary and secondary adapters
+
+The Ports and Adapters architecture defines two kind of adapters:
+*Primary* (or driving) adapters
+and *secondary* (or driven) adapters.
+
+> A primary actor is an actor that drives the application
+> (takes it out of quiescent state to perform one of its advertised functions).
+> A secondary actor is one that the application drives,
+> either to get answers from or to merely notify.
+> The distinction between primary and secondary lies in who triggers
+> or is in charge of the conversation.
+
+
+## Example architecture
+
+```mermaid
+---
+  config:
+    class:
+      hideEmptyMembersBox: true
+---
+classDiagram
+    direction LR
+
+    note "In a ports and adapters (hexagonal) architecture,
+    all dependencies point towards the application core.
+    That is, the application core has no dependencies.
+    Instead, the application defines interfaces (ports)
+    that are implemented by adapters that translate the
+    application specifics into infrastructure details."
+
+    note for UserStore "This is a port for storing users persistently.
+    It is independent of any specific storage technology.
+    It could be implemented by a Spring Data repository,
+    an in memory database, a flat file or any other means."
+
+    note for SpringUserStore "This is an implementation of the UserStore
+    that adapts the application specific port
+    to storage backed by a Spring Data repository."
+
+    note for UserService "This class provides a technology agnostic interface (port)
+    to the application logic. For simplicity, there is no
+    distinct Java interface for this port. Instead, the
+    public interface of the class defines the port. If
+    needed, we could split the class into a UserService
+    interface (port) and an implementing class
+    'DiggUserService'. This would give us the ability to
+    test the UserController using a UserService test
+    double."
+
+    namespace com.example.demo.application {
+        class UserService
+        class UserStore
+        class User
+        class UserData
+    }
+    namespace com.example.demo.spring.web {
+        class UserController
+        class UserResource
+    }
+    namespace com.example.demo.spring.data {
+        class SpringUserStore
+        class UserRepository
+        class UserEntity
+    }
+    namespace org.springframework.data.repository {
+        class CrudRepository
+    }
+    namespace org.springframework.web.bind.annotation {
+        class RequestMapping
+        class GetMapping
+        class PostMapping
+    }
+    UserController --> UserService
+    <<record>> UserData
+    <<record>> UserResource
+    <<interface>> UserStore
+    UserStore <-- UserService
+    UserStore <|-- SpringUserStore
+    User <-- SpringUserStore
+    UserEntity <|-- SpringUserStore
+    UserRepository <-- SpringUserStore
+    UserEntity <-- UserRepository
+
+    UserService --> UserData
+    UserService : get(id) UserData
+    UserService : save(UserData user)
+
+    UserStore --> User
+    UserStore : get(id) User
+    UserStore : save(User user)
+
+    UserRepository : findById(id) Optional~UserEnity~
+    UserRepository : save(UserEntity user)
+
+    CrudRepository <|-- UserRepository
+
+    <<annotation>> RequestMapping
+    <<annotation>> GetMapping
+    <<annotation>> PostMapping
+
+    UserController --> UserData
+    UserController --> UserResource
+
+    RequestMapping <-- UserController
+    GetMapping <-- UserController
+    PostMapping <-- UserController
+```
+
+
+## Testing
+
+With the architecture defined above,
+a number of different types of automated tests are possible.
+Each of the identified test types are defined in a separate document.
+
+- [Component test](./component-test.md)
+- [Application test](./application-test.md)
+- [Primary adapter test](./primary-adapter-test.md)
+- [Secondary adapter test](./secondary-adapter-test.md)

--- a/src/main/markdown/component-test.md
+++ b/src/main/markdown/component-test.md
@@ -1,0 +1,71 @@
+<!--
+SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Component Test (Draft)
+
+In the component test
+we deploy and run the application as a separate process
+and test it through its external interface.
+For a REST service,
+this means testing by sending HTTP requests
+and inspecting the responses.
+
+For persistence,
+we are free to choose between a real database
+(potentially running in a test container)
+or using an in memory implementation of the corresponding adapter.
+In the diagram below
+we are using a database running in a test container.
+
+```mermaid
+---
+  config:
+    class:
+      hideEmptyMembersBox: true
+---
+classDiagram
+    direction LR
+
+    note "Here we test with the whole service deployed locally
+    and running as a separate process. We have a database
+    running in test container managed by the test
+    instance. The test interacts with the service through
+    its API and can also inspect the database directly."
+
+    class ComponentTest
+    ComponentTest --> UserController : HTTP
+    ComponentTest --> TestDatabase : JDBC
+
+    class TestDatabase
+    <<testcontainer>> TestDatabase
+    TestDatabase <-- UserRepository : JDBC
+
+    namespace com.example.demo.application {
+        class UserService
+        class UserStore
+    }
+    namespace com.example.demo.spring.web {
+        class UserController
+    }
+    namespace com.example.demo.spring.data {
+        class SpringUserStore
+        class UserRepository
+    }
+    UserController --> UserService
+    <<interface>> UserStore
+    UserStore <-- UserService
+    UserStore <|-- SpringUserStore
+    UserRepository <-- SpringUserStore
+
+    UserService : get(id) UserData
+    UserService : save(UserData user)
+
+    UserStore : get(id) User
+    UserStore : save(User user)
+
+    UserRepository : findById(id) Optional~UserEnity~
+    UserRepository : save(UserEntity user)
+```

--- a/src/main/markdown/primary-adapter-test.md
+++ b/src/main/markdown/primary-adapter-test.md
@@ -1,0 +1,73 @@
+<!--
+SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Primary adapter test (Draft)
+
+When testing a primary adapter
+we can either write a regular unit test
+backed by a mocked version of the primary port
+or we could use the real thing
+and have test doubles for the secondary adapters.
+To have better control and reduce complexity,
+it is prefereable to mock the primary port.
+
+In the case of or example,
+that means we want to mock the `UserService`.
+
+```mermaid
+---
+  config:
+    class:
+      hideEmptyMembersBox: true
+---
+classDiagram
+    direction LR
+
+    note for MockUserService "By mocking the UserService
+    we can easily test that the
+    UserController translates
+    application specific behaviour
+    into expected API responses.
+    "
+
+    class UserControllerTest
+    UserControllerTest --> UserController
+    UserControllerTest --> MockUserService
+    MockUserService --|> UserService
+
+    namespace com.example.demo.application {
+        class UserService
+        class UserData
+    }
+    namespace com.example.demo.spring.web {
+        class UserController
+        class UserResource
+    }
+    namespace org.springframework.web.bind.annotation {
+        class RequestMapping
+        class GetMapping
+        class PostMapping
+    }
+    <<interface>> UserService
+    UserController --> UserService
+    <<record>> UserData
+    <<record>> UserResource
+
+    UserService --> UserData
+    UserService : get(id) UserData
+    UserService : save(UserData user)
+
+    <<annotation>> RequestMapping
+    <<annotation>> GetMapping
+    <<annotation>> PostMapping
+
+    UserController --> UserData
+    UserController --> UserResource
+
+    RequestMapping <-- UserController
+    GetMapping <-- UserController
+    PostMapping <-- UserController
+```

--- a/src/main/markdown/secondary-adapter-test.md
+++ b/src/main/markdown/secondary-adapter-test.md
@@ -1,0 +1,87 @@
+<!--
+SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Secondary Adapter Test (Draft)
+
+A secondary (or driven) adapter translates application needs into a particular technology or framework.
+Let's consider our `SpringUserStore`.
+It adapts the need of the application to retrieve and store users persistently
+by leveraging the Spring data framework to store users in a database.
+To test this code,
+it makes sense to have an integrated test against a real database.
+This way we can gain confidence that our use of the framework actually works the way we think.
+Should we instead use a mocked database
+and only check that the expected calls are made to the database,
+our tests would be
+more tightly coupled to the implementation,
+more likely to break on changes to the production code
+and also give us less confidence that the production code actually works.
+
+```mermaid
+---
+  config:
+    class:
+      hideEmptyMembersBox: true
+---
+classDiagram
+    direction TB
+
+    note "Here we test that we can correctly
+    store and retreive User domain
+    objects in a database via our
+    Spring Data implementation.
+    By testing the database integration
+    thoroughly here, we can safely use a test
+    double for the UserStore in other tests.
+    "
+
+    note for UserStore "By defining an application specific interface,
+    the UserStore, instead of using the
+    UserRepository directly in the application
+    logic, we minimize the interface between the
+    core application and the storage mechanism.
+    This in turn reduces the amount of cases we
+    need to test"
+
+    namespace com.example.demo.application {
+        class UserStore
+        class User
+    }
+    namespace com.example.demo.spring.data {
+        class SpringUserStore
+        class UserRepository
+        class UserEntity
+    }
+    namespace org.springframework.data.repository {
+        class CrudRepository
+    }
+    <<interface>> UserStore
+    UserStore <|-- SpringUserStore
+    User <-- SpringUserStore
+    UserEntity <|-- SpringUserStore
+    UserRepository <-- SpringUserStore
+    UserEntity <-- UserRepository
+
+    UserStore --> User
+    UserStore : get(id) User
+    UserStore : save(User user)
+
+    UserRepository : findById(id) Optional~UserEnity~
+    UserRepository : save(UserEntity user)
+
+    CrudRepository <|-- UserRepository
+
+    class SpringUserStore
+    SpringUserStoreTest --> UserStore
+    SpringUserStoreTest --> SpringUserStore
+    SpringUserStoreTest --> User
+    SpringUserStoreTest --> TestDatabase : Manages lifecycle of
+
+    CrudRepository --> TestDatabase
+
+    class TestDatabase
+    <<testcontainer>> TestDatabase
+```


### PR DESCRIPTION
# Pull Request Description

This pull request adds draft documentation for an architecture based on Alistair Cockburn's [Hexagonal (Ports & Adapters) Architecture](https://alistair.cockburn.us/hexagonal-architecture).

All documents are placed in [./src/main/markdown](./src/main/markdown) and the main document is the [Architecture Overview](./src/main/markdown/architecture-overview.md). A number of documents on various ways to test the service are also included and referenced by the main document.

Note: This is only a suggestion and not at all final. The purpose is to spark conversions in the team so that we can eventually find an acceptable way forward.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
