### PR TITLE
Add GitHub Action for pull request workflow

### DIFF
--- a/.github/workflows/pullrequest-workflow.yml
+++ b/.github/workflows/pullrequest-workflow.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 diggsweden/eudiw-wallet-token-lib
+# SPDX-FileCopyrightText: 2025 diggsweden/wallet-backend-reference
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 diggsweden/eudiw-wallet-token-lib
+# SPDX-FileCopyrightText: 2025 diggsweden/wallet-backend-reference
 #
 # SPDX-License-Identifier: CC0-1.0
 


### PR DESCRIPTION
The workflow files are copied verbatim from the eudiw-wallet-token-lib
repository and minimally adopted to the wallet backend reference codebase. Specifically we have:

1. Applied default Prettier formatting rules
2. Updated the copyright owner of each file  

See: EUDIW-667
See: https://github.com/diggsweden/eudiw-wallet-token-lib/tree/main/.github/workflows
Signed-off-by: Eric Thelin <extern.eric.thelin@digg.se>

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
