### PR TITLE
fix: use available version of PostgresSQL docker image

### DIFF
--- a/src/test/java/com/example/demo/TestcontainersConfiguration.java
+++ b/src/test/java/com/example/demo/TestcontainersConfiguration.java
@@ -16,7 +16,7 @@ public class TestcontainersConfiguration {
   @Bean
   @ServiceConnection
   PostgreSQLContainer<?> postgresContainer() {
-    return new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"));
+    return new PostgreSQLContainer<>(DockerImageName.parse("postgres:14-alpine"));
   }
 
 }


### PR DESCRIPTION
For some reason we can no longer pull `postgres:latest` from the Digg Docker image registry. This makes the test suite fail when running on a Digg computer. On GitHub everything seems to work, i.e. the test suite passes. This is probably because we on GitHub go directly to the official Docker registry and not via Digg.

To be more specific, when we run

    docker pull registry.digg.se:5050/postgres:latest

we get the following error:

    error pulling image configuration: download failed after attempts=1: unknown blob

This could potentially be a bug in Nexus. However, a workaround for now is to use a version of the docker image that can actually be pulled from Digg. One such version is `14-alpine` which was added to the Digg Nexus server on 2025-02-17.

See: https://github.com/sonatype/nexus-public/issues/264

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
