### PR TITLE
feat: ignore missing Javadoc comments

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+SPDX-FileCopyrightText: 2025 diggsweden/wallet-backend-reference
+
+SPDX-License-Identifier: EUPL-1.2
+-->
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+</suppressions>

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -9,4 +9,5 @@ SPDX-License-Identifier: EUPL-1.2
   "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+  <suppress message="Missing a Javadoc comment"/>
 </suppressions>


### PR DESCRIPTION
We strive to write self explanatory code, therefore removing this check.
This removes 19 warnings from the current code base.

Note: This achieves the same result as pull request #8 by
@markus-beer-digg, but avoids the need to modify the google_checks.xml
file and the potential associated license issues. Also, it is probably
easier to see exactly which exceptions we have to the standard google
checks when we have all exceptions in a separate file.

See: https://checkstyle.org/google_style.html#Suppressions
See: https://checkstyle.org/filters/suppressionfilter.html
Signed-off-by: Eric Thelin <extern.eric.thelin@digg.se>

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
