### PR TITLE
ci(lint): extend commitlint length

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -30,3 +30,4 @@ policies:
             "release",
           ]
         scopes: [".*"]
+        descriptionLength: 92


### PR DESCRIPTION
Our autotools, (Renovate, I'm looking at you), might at times add longer commit descriptions than the default 72. So as to avoid unneccessary lint fails, we raise it a bit, enough to handle all Renovate commits we have seen so far in other PR's. This has been done on all projects using conform at diggsweden, and this PR is a part of that.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
