### PR TITLE
chore(ci): pin reusable-ci to feat/improve-rust-chain

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -20,6 +20,6 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    uses: diggsweden/reusable-ci/.github/workflows/security-openssf-scorecard.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/security-openssf-scorecard.yml@cd56d63b88cf6f1ebb4dc3431986f4208ab85fc5 # v2.8.1
     with:
       publish-results: true

--- a/.github/workflows/pullrequest-workflow.yml
+++ b/.github/workflows/pullrequest-workflow.yml
@@ -17,14 +17,14 @@ permissions:
 
 jobs:
   pr-checks:
-    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@cd56d63b88cf6f1ebb4dc3431986f4208ab85fc5 # v2.8.1
     secrets: inherit # Pass org-level secrets (for private Maven dependencies)
     permissions:
       contents: read # Clone repository and read source code
       packages: read # Access GitHub Packages for Maven dependencies
       security-events: write # Upload SpotBugs/dependency check results to Security tab
     with:
-      reusable-ci-ref: v2.7.9
+      reusable-ci-ref: cd56d63b88cf6f1ebb4dc3431986f4208ab85fc5
       project-type: maven
       # Use devbase-check linting (replaces megalint, commitlint, licenselint)
       linters.devbasecheck: true

--- a/.github/workflows/release-dev-workflow.yml
+++ b/.github/workflows/release-dev-workflow.yml
@@ -24,8 +24,12 @@ jobs:
     permissions:
       contents: read # Read code for building
       packages: write # Push dev images to ghcr.io
-    uses: diggsweden/reusable-ci/.github/workflows/release-dev-orchestrator.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/release-dev-orchestrator.yml@cd56d63b88cf6f1ebb4dc3431986f4208ab85fc5 # v2.8.1
     with:
-      reusable-ci-ref: v2.7.9
+      reusable-ci-ref: cd56d63b88cf6f1ebb4dc3431986f4208ab85fc5
       project-type: maven
+      # Exercise the full dev SBOM pipeline (build + analyzed-artifact +
+      # analyzed-container) on this maven reference repo. r2ps stays on
+      # the default `none` for fast feedback.
+      sboms: all
     secrets: inherit

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   release:
-    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@0d87fcd4cd9550e50bfa1923b98afbed80708325 # v2.7.9
+    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@cd56d63b88cf6f1ebb4dc3431986f4208ab85fc5 # v2.8.1
     permissions:
       contents: write # Create GitHub releases and tags
       packages: write # Publish JARs to GitHub Packages and images to ghcr.io
@@ -33,7 +33,7 @@ jobs:
       attestations: write # Attach SBOM attestation to container images
     secrets: inherit # Use org-level GPG keys if configured
     with:
-      reusable-ci-ref: v2.7.9
+      reusable-ci-ref: cd56d63b88cf6f1ebb4dc3431986f4208ab85fc5
       artifacts-config: .github/artifacts.yml
       changelog-creator: git-cliff
       release-publisher: github-cli


### PR DESCRIPTION
Test branch for smoke-testing the new reusable-ci branch's artefact-first paths against this maven project. Includes the v2.9 multi-arch container builds (artifacts.yml already has platforms: linux/amd64,linux/arm64) and the OpenGrep security fixes.

Will switch back to the v2.9.0 tag once cut.

# Pull Request Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [ ] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
